### PR TITLE
Fix nested array transformation

### DIFF
--- a/epoch/version_change_builder.go
+++ b/epoch/version_change_builder.go
@@ -119,12 +119,12 @@ func (b *versionChangeBuilder) Build() *VersionChange {
 								return err
 							}
 						} else {
-							// For objects, apply operations to the object and handle nested arrays
+							// For objects, apply operations to the top-level object first
 							if err := pb.operations.ApplyToResponse(resp.Body); err != nil {
 								return err
 							}
-							// Handle nested arrays within objects
-							if err := resp.TransformArrayField("", func(node *ast.Node) error {
+							// Then recursively handle ALL nested arrays within the object
+							if err := resp.TransformNestedArrays(func(node *ast.Node) error {
 								return pb.operations.ApplyToResponse(node)
 							}); err != nil {
 								return err

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/bytedance/sonic/loader v0.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/cloudwego/iasm v0.2.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.3 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
@@ -37,6 +38,8 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.12 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -110,6 +110,8 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
 github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=


### PR DESCRIPTION
## Description

Problem

- Declarative API transformations (RenameField, AddField, etc.) were not applying to fields inside array items
- Only worked on top-level fields and top-level arrays, but not nested arrays within objects
- Example: {examples: [{name: "test"}]} - the name field inside the array items was not being transformed

Root Cause

- version_change_builder.go only handled top-level arrays with TransformArrayField("")
- No recursive traversal for arrays nested within objects
- Transformations stopped at object level, missing nested array structures

Solution

- Added TransformNestedArrays() method to ResponseInfo for recursive array traversal
- Added transformNestedArraysRecursive() helper to handle deeply nested structures
- Updated response transformer in version_change_builder.go to call both top-level and nested array transformations


## 🎟 Issue(s)

#40 

## 🧪 Functional Testing

<!--- List the functional testing steps to confirm this feature or fix. --->

## 📸 Screenshots

<!--- Add screenshots to illustrate the validity of these changes. --->

## 📋 Checklist

- [ ] Added/updated applicable tests
- [ ] Added/updated examples in the `examples/` directory
- [ ] Updated any related documentation
