### PR TITLE
fix swag integration with request schemas

### DIFF
--- a/epoch/openapi/generator_test.go
+++ b/epoch/openapi/generator_test.go
@@ -444,12 +444,18 @@ func TestSchemaGenerator_TransformSwagSchemas(t *testing.T) {
 	v1, _ := epoch.NewSemverVersion("1.0")
 	headVersion := epoch.NewHeadVersion()
 
+	// Migration from v1 to HEAD
+	// v1 has: name
+	// HEAD has: betterNewName, timezone
 	change := epoch.NewVersionChangeBuilder(v1, headVersion).
 		Description("Add betterNewName and timezone fields").
 		ForType(UpdateExampleRequest{}).
 		ResponseToPreviousVersion().
 		RenameField("betterNewName", "name").
 		RemoveField("timezone").
+		RequestToNextVersion().
+		RenameField("name", "betterNewName").
+		AddField("timezone", "").
 		Build()
 
 	vb, err := epoch.NewVersionBundle([]*epoch.Version{headVersion, v1})


### PR DESCRIPTION
## Description

Currently, schema generation does not work with request models. This is because requests are migrated from current to next version, and not backwards from head (like responses). This PR adds logic to automatically inverse migrations for requests so that we can generate schema for them.

<!--- Describe the purpose of this pull request. --->

## 🎟 Issue(s)
#59 

## 🧪 Functional Testing

<!--- List the functional testing steps to confirm this feature or fix. --->

## 📸 Screenshots

<!--- Add screenshots to illustrate the validity of these changes. --->

## 📋 Checklist

- [ ] Added/updated applicable tests
- [ ] Added/updated examples in the `examples/` directory
- [ ] Updated any related documentation
