### PR TITLE
refactor: rename parameter fields for renameField

### DIFF
--- a/epoch/openapi/version_transformer.go
+++ b/epoch/openapi/version_transformer.go
@@ -275,7 +275,7 @@ func (vt *VersionTransformer) applyOperationToSchema(
 
 	case *epoch.ResponseRenameField:
 		// Rename a field in the response schema
-		vt.RenameFieldInSchema(schema, operation.From, operation.To)
+		vt.RenameFieldInSchema(schema, operation.NewerVersionName, operation.OlderVersionName)
 
 	case *epoch.RequestAddField:
 		// Add a field to the request schema
@@ -293,7 +293,7 @@ func (vt *VersionTransformer) applyOperationToSchema(
 
 	case *epoch.RequestRenameField:
 		// Rename a field in the request schema
-		vt.RenameFieldInSchema(schema, operation.From, operation.To)
+		vt.RenameFieldInSchema(schema, operation.OlderVersionName, operation.NewerVersionName)
 
 	case *epoch.ResponseRemoveFieldIfDefault:
 		// For schema generation, treat this as a regular remove

--- a/epoch/version_change_builder.go
+++ b/epoch/version_change_builder.go
@@ -279,11 +279,11 @@ func (b *requestToNextVersionBuilder) RemoveField(name string) *requestToNextVer
 }
 
 // RenameField renames a field when request migrates from client to HEAD
-func (b *requestToNextVersionBuilder) RenameField(from, to string) *requestToNextVersionBuilder {
+func (b *requestToNextVersionBuilder) RenameField(olderVersionName, newerVersionName string) *requestToNextVersionBuilder {
 	b.parent.requestToNextVersionOps = append(b.parent.requestToNextVersionOps,
 		&RequestRenameField{
-			From: from,
-			To:   to,
+			OlderVersionName: olderVersionName,
+			NewerVersionName: newerVersionName,
 		})
 	return b
 }
@@ -351,11 +351,11 @@ func (b *responseToPreviousVersionBuilder) RemoveFieldIfDefault(name string, def
 }
 
 // RenameField renames a field when response migrates from HEAD to client
-func (b *responseToPreviousVersionBuilder) RenameField(from, to string) *responseToPreviousVersionBuilder {
+func (b *responseToPreviousVersionBuilder) RenameField(newerVersionName, olderVersionName string) *responseToPreviousVersionBuilder {
 	b.parent.responseToPreviousVersionOps = append(b.parent.responseToPreviousVersionOps,
 		&ResponseRenameField{
-			From: from,
-			To:   to,
+			NewerVersionName: newerVersionName,
+			OlderVersionName: olderVersionName,
 		})
 	return b
 }


### PR DESCRIPTION
## Description

This PR renames the parameter fields for `renameField` so instead of `from` and `to`, it is now `OlderVersionName` and `NewerVersionName`.
<!--- Describe the purpose of this pull request. --->

## 🎟 Issue(s)
#73 
## 🧪 Functional Testing

<!--- List the functional testing steps to confirm this feature or fix. --->

## 📸 Screenshots

<!--- Add screenshots to illustrate the validity of these changes. --->

## 📋 Checklist

- [ ] Added/updated applicable tests
- [ ] Added/updated examples in the `examples/` directory
- [ ] Updated any related documentation
