### PR TITLE
refactor: remove string versioning support

### DIFF
--- a/epoch/epoch.go
+++ b/epoch/epoch.go
@@ -244,15 +244,6 @@ func (cb *EpochBuilder) WithSemverVersions(semvers ...string) *EpochBuilder {
 	return cb
 }
 
-// WithStringVersions creates and adds string-based versions
-func (cb *EpochBuilder) WithStringVersions(versions ...string) *EpochBuilder {
-	for _, versionStr := range versions {
-		v := NewStringVersion(versionStr)
-		cb.versions = append(cb.versions, v)
-	}
-	return cb
-}
-
 // WithHeadVersion adds a head version
 func (cb *EpochBuilder) WithHeadVersion() *EpochBuilder {
 	cb.versions = append(cb.versions, NewHeadVersion())
@@ -360,21 +351,10 @@ func WithSemver(semvers ...string) (*Epoch, error) {
 	return builder.Build()
 }
 
-// WithStringVersions creates an Epoch instance with string versions and head version
-func WithStrings(versions ...string) (*Epoch, error) {
-	builder := NewEpoch().WithStringVersions(versions...).WithHeadVersion()
-	return builder.Build()
-}
-
 // Simple creates an Epoch instance with just a head version
 func Simple() (*Epoch, error) {
 	builder := NewEpoch().WithHeadVersion()
 	return builder.Build()
-}
-
-// StringVersion creates a string version (convenience wrapper)
-func StringVersion(version string) *Version {
-	return NewStringVersion(version)
 }
 
 // HeadVersion creates a head version

--- a/epoch/epoch_test.go
+++ b/epoch/epoch_test.go
@@ -72,13 +72,6 @@ var _ = Describe("Cadwyn", func() {
 			})
 		})
 
-		Describe("WithStringVersions", func() {
-			It("should create and add string versions", func() {
-				result := builder.WithStringVersions("alpha", "beta", "stable")
-				Expect(result).To(Equal(builder))
-			})
-		})
-
 		Describe("WithHeadVersion", func() {
 			It("should add a head version", func() {
 				result := builder.WithHeadVersion()
@@ -235,14 +228,6 @@ var _ = Describe("Cadwyn", func() {
 			})
 		})
 
-		Describe("WithStrings", func() {
-			It("should create a Cadwyn instance with string versions", func() {
-				cadwynInstance, err := WithStrings("alpha", "beta")
-				Expect(err).NotTo(HaveOccurred())
-				Expect(cadwynInstance).NotTo(BeNil())
-			})
-		})
-
 		Describe("Simple", func() {
 			It("should create a Cadwyn instance with just head version", func() {
 				cadwynInstance, err := Simple()
@@ -253,13 +238,6 @@ var _ = Describe("Cadwyn", func() {
 	})
 
 	Describe("Version helpers", func() {
-		Describe("StringVersion", func() {
-			It("should create a string version", func() {
-				version := StringVersion("alpha")
-				Expect(version.Type).To(Equal(VersionTypeString))
-			})
-		})
-
 		Describe("HeadVersion", func() {
 			It("should create a head version", func() {
 				version := HeadVersion()

--- a/epoch/integration_test.go
+++ b/epoch/integration_test.go
@@ -1033,10 +1033,6 @@ var _ = Describe("End-to-End Integration Tests", func() {
 			Expect(err2).NotTo(HaveOccurred())
 			Expect(instance2).NotTo(BeNil())
 
-			instance3, err3 := WithStrings("alpha", "beta", "stable")
-			Expect(err3).NotTo(HaveOccurred())
-			Expect(instance3).NotTo(BeNil())
-
 			instance4, err4 := Simple()
 			Expect(err4).NotTo(HaveOccurred())
 			Expect(instance4).NotTo(BeNil())

--- a/epoch/middleware.go
+++ b/epoch/middleware.go
@@ -20,7 +20,6 @@ type VersionFormat string
 const (
 	VersionFormatDate   VersionFormat = "date"
 	VersionFormatSemver VersionFormat = "semver"
-	VersionFormatString VersionFormat = "string"
 )
 
 // VersionManager checks all locations for version information
@@ -296,13 +295,7 @@ func (vm *VersionMiddleware) isValidVersionFormat(versionStr string) bool {
 		return true
 	}
 
-	// For string versions, we're more permissive but exclude obviously invalid ones
-	// like "invalid" which is clearly not a version
-	if versionStr == "invalid" || versionStr == "unknown" || versionStr == "error" {
-		return false
-	}
-
-	return true
+	return false
 }
 
 // GetVersionFromContext extracts the version from the Gin context

--- a/epoch/version.go
+++ b/epoch/version.go
@@ -36,7 +36,6 @@ type VersionType int
 const (
 	VersionTypeDate VersionType = iota
 	VersionTypeSemver
-	VersionTypeString
 	VersionTypeHead
 )
 
@@ -47,8 +46,6 @@ func (vt VersionType) String() string {
 		return "date"
 	case VersionTypeSemver:
 		return "semver"
-	case VersionTypeString:
-		return "string"
 	case VersionTypeHead:
 		return "head"
 	default:
@@ -70,10 +67,7 @@ func NewVersion(value string, changes ...VersionChangeInterface) (*Version, erro
 		return version, nil
 	}
 
-	// Fallback to string version
-	version := NewStringVersion(value, changes...)
-	version.Changes = changes
-	return version, nil
+	return nil, fmt.Errorf("invalid version format '%s': must be a date (YYYY-MM-DD) or semver (X.Y.Z or X.Y)", value)
 }
 
 // NewDateVersion creates a new date-based version
@@ -128,16 +122,6 @@ func NewSemverVersion(semverStr string) (*Version, error) {
 	return nil, fmt.Errorf("invalid semver format '%s': expected major.minor.patch or major.minor", semverStr)
 }
 
-// NewStringVersion creates a new string-based version
-func NewStringVersion(versionStr string, changes ...VersionChangeInterface) *Version {
-	return &Version{
-		Raw:     versionStr,
-		Type:    VersionTypeString,
-		IsHead:  false,
-		Changes: changes,
-	}
-}
-
 // NewHeadVersion creates a head (latest) version
 func NewHeadVersion(changes ...VersionChangeInterface) *Version {
 	return &Version{
@@ -188,13 +172,6 @@ func (v *Version) Compare(other *Version) int {
 		return 1
 	}
 
-	// Fallback to string comparison
-	if v.Raw < other.Raw {
-		return -1
-	}
-	if v.Raw > other.Raw {
-		return 1
-	}
 	return 0
 }
 

--- a/epoch/version_test.go
+++ b/epoch/version_test.go
@@ -83,21 +83,6 @@ var _ = Describe("Version", func() {
 		})
 	})
 
-	Describe("NewStringVersion", func() {
-		It("should create a string-based version", func() {
-			version := NewStringVersion("alpha")
-			Expect(version.Type).To(Equal(VersionTypeString))
-			Expect(version.Raw).To(Equal("alpha"))
-			Expect(version.IsHead).To(BeFalse())
-		})
-
-		It("should handle empty string", func() {
-			version := NewStringVersion("")
-			Expect(version.Type).To(Equal(VersionTypeString))
-			Expect(version.Raw).To(Equal(""))
-		})
-	})
-
 	Describe("NewHeadVersion", func() {
 		It("should create a head version", func() {
 			version := NewHeadVersion()
@@ -120,10 +105,10 @@ var _ = Describe("Version", func() {
 			Expect(version.Type).To(Equal(VersionTypeSemver))
 		})
 
-		It("should fallback to string version", func() {
-			version, err := NewVersion("alpha")
-			Expect(err).NotTo(HaveOccurred())
-			Expect(version.Type).To(Equal(VersionTypeString))
+		It("should return an error for invalid version format", func() {
+			_, err := NewVersion("alpha")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("invalid version format"))
 		})
 	})
 
@@ -134,8 +119,8 @@ var _ = Describe("Version", func() {
 		})
 
 		It("should return raw value for non-head versions", func() {
-			version := NewStringVersion("alpha")
-			Expect(version.String()).To(Equal("alpha"))
+			version, _ := NewSemverVersion("1.0.0")
+			Expect(version.String()).To(Equal("1.0.0"))
 		})
 	})
 
@@ -203,7 +188,6 @@ var _ = Describe("Version", func() {
 		It("should return correct string representations", func() {
 			Expect(VersionTypeDate.String()).To(Equal("date"))
 			Expect(VersionTypeSemver.String()).To(Equal("semver"))
-			Expect(VersionTypeString.String()).To(Equal("string"))
 			Expect(VersionTypeHead.String()).To(Equal("head"))
 		})
 	})


### PR DESCRIPTION
## Description

  Removes arbitrary string versioning support (VersionTypeString, NewStringVersion()) from Epoch.
  Previously, NewVersion() silently fell back to creating a string-typed version for any input that
   wasn't a valid date or semver, which enabled ambiguous parsing and lexicographic ordering
  comparisons.

  Now, NewVersion() returns an error for non-date/non-semver values, enforcing strict version
  format validation at parse time. This is a breaking change.

  Changes:

  - Removed VersionTypeString from the VersionType enum
  - Removed NewStringVersion(), WithStringVersions(), WithStrings(), and StringVersion() functions
  - Removed VersionFormatString constant
  - NewVersion() now returns an error instead of falling back to string for invalid formats
  - Simplified isValidVersionFormat() to only accept date (YYYY-MM-DD) and semver (X.Y.Z / X.Y)
  formats
  - Removed lexicographic string comparison fallback from Compare()




## 🎟 Issue(s)

  CPP-410: Design proposal: remove string versioning, support only date + semver


## 🧪 Functional Testing
  - All existing unit and integration tests pass after updating test expectations
  - NewVersion("alpha") now returns an error with message "invalid version format 'alpha': must be
  a date (YYYY-MM-DD) or semver (X.Y.Z or X.Y)"
  - NewVersion("2024-01-01") and NewVersion("1.0.0") continue to work as expected
  - Middleware waterfall logic correctly rejects non-date/non-semver version strings
<!--- List the functional testing steps to confirm this feature or fix. --->

## 📸 Screenshots

<!--- Add screenshots to illustrate the validity of these changes. --->

## 📋 Checklist

- [ ] Added/updated applicable tests
- [ ] Added/updated examples in the `examples/` directory
- [ ] Updated any related documentation
